### PR TITLE
Growable buffers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# next
+* Remove Buffer_is_full in favor of Bytebuffers that can grow upto a user provided max size
+
 # 0.4.0
 * Remove Bytebuffer from public api
 * Deprecate `schedule_bigstring`, `write_string`

--- a/core/lib/bytebuffer.mli
+++ b/core/lib/bytebuffer.mli
@@ -4,7 +4,8 @@ type t [@@deriving sexp_of]
 
 val unsafe_buf : t -> Bigstring.t
 val pos : t -> int
-val create : int -> t
+val create : ?max_buffer_size:int -> int -> t
+val maybe_grow_buffer : t -> int -> unit
 val can_reclaim_space : t -> bool
 val capacity : t -> int
 val available_to_write : t -> int

--- a/core/lib/connection.ml
+++ b/core/lib/connection.ml
@@ -21,7 +21,9 @@ let listen
   ?backlog
   ?socket
   ?input_buffer_size
+  ?max_input_buffer_size
   ?output_buffer_size
+  ?max_output_buffer_size
   ~on_handler_error
   ~f:handler
   where_to_listen
@@ -35,8 +37,18 @@ let listen
     where_to_listen
     (fun addr socket ->
     let fd = Socket.fd socket in
-    let input_channel = Input_channel.create ?buf_len:input_buffer_size fd in
-    let output_channel = Output_channel.create ?buf_len:output_buffer_size fd in
+    let input_channel =
+      Input_channel.create
+        ?max_buffer_size:max_input_buffer_size
+        ?buf_len:input_buffer_size
+        fd
+    in
+    let output_channel =
+      Output_channel.create
+        ?max_buffer_size:max_output_buffer_size
+        ?buf_len:output_buffer_size
+        fd
+    in
     let%bind res =
       Deferred.any
         [ collect_errors output_channel (fun () ->
@@ -55,14 +67,26 @@ let with_connection
   ?interrupt
   ?timeout
   ?input_buffer_size
+  ?max_input_buffer_size
   ?output_buffer_size
+  ?max_output_buffer_size
   ~f
   where_to_connect
   =
   let%bind socket = Tcp.connect_sock ?interrupt ?timeout where_to_connect in
   let fd = Socket.fd socket in
-  let input_channel = Input_channel.create ?buf_len:input_buffer_size fd in
-  let output_channel = Output_channel.create ?buf_len:output_buffer_size fd in
+  let input_channel =
+    Input_channel.create
+      ?max_buffer_size:max_input_buffer_size
+      ?buf_len:input_buffer_size
+      fd
+  in
+  let output_channel =
+    Output_channel.create
+      ?max_buffer_size:max_output_buffer_size
+      ?buf_len:output_buffer_size
+      fd
+  in
   let res = collect_errors output_channel (fun () -> f input_channel output_channel) in
   let%bind () =
     Deferred.any_unit

--- a/core/lib/connection.mli
+++ b/core/lib/connection.mli
@@ -13,7 +13,9 @@ val listen
   -> ?backlog:int
   -> ?socket:([ `Unconnected ], ([< Socket.Address.t ] as 'address)) Socket.t
   -> ?input_buffer_size:int
+  -> ?max_input_buffer_size:int
   -> ?output_buffer_size:int
+  -> ?max_output_buffer_size:int
   -> on_handler_error:[ `Call of 'address -> exn -> unit | `Ignore | `Raise ]
   -> f:('address -> Input_channel.t -> Output_channel.t -> unit Deferred.t)
   -> ('address, 'listening_on) Tcp.Where_to_listen.t
@@ -26,7 +28,9 @@ val with_connection
   :  ?interrupt:unit Deferred.t
   -> ?timeout:Time.Span.t
   -> ?input_buffer_size:int
+  -> ?max_input_buffer_size:int
   -> ?output_buffer_size:int
+  -> ?max_output_buffer_size:int
   -> f:(Input_channel.t -> Output_channel.t -> 'res Deferred.t)
   -> [< Socket.Address.t ] Tcp.Where_to_connect.t
   -> 'res Async_kernel__Types.Deferred.t

--- a/core/lib/input_channel.mli
+++ b/core/lib/input_channel.mli
@@ -8,11 +8,11 @@ open Async_unix
 
 type t [@@deriving sexp_of]
 
-val create : ?buf_len:int -> Fd.t -> t
+val create : ?max_buffer_size:int -> ?buf_len:int -> Fd.t -> t
 val is_closed : t -> bool
 val closed : t -> unit Deferred.t
 val close : t -> unit Deferred.t
-val refill : t -> [ `Ok | `Eof | `Buffer_is_full ] Deferred.t
+val refill : t -> [ `Ok | `Eof ] Deferred.t
 val view : t -> Bigstring.t Core_unix.IOVec.t
 val consume : t -> int -> unit
 

--- a/core/lib/output_channel.mli
+++ b/core/lib/output_channel.mli
@@ -8,11 +8,16 @@ open Async_unix
 
 type t [@@deriving sexp_of]
 
-(** [create ?buf_len ?write_timeout fd] creates a new writer.
+(** [create ?max_buffer_size ?buf_len ?write_timeout fd] creates a new writer.
 
     The writer doesn't flush automatically and the user is responsible for calling
     [flush], which triggers a write system call if needed. *)
-val create : ?buf_len:int -> ?write_timeout:Time_ns.Span.t -> Fd.t -> t
+val create
+  :  ?max_buffer_size:int
+  -> ?buf_len:int
+  -> ?write_timeout:Time_ns.Span.t
+  -> Fd.t
+  -> t
 
 (** [monitor] returns the async monitor used by [Output_channel] for performing all write
     operations.*)


### PR DESCRIPTION
Instead of using `Buffer_is_full automatically grow bytebuffers up to
the max allowable buffer length.