### PR TITLE
More robust flush management

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # next
 * Remove Buffer_is_full in favor of Bytebuffers that can grow upto a user provided max size
+* Flush operations reports if the write operations encountered an error
+* Reliably wakeup pending flushes when there is an error encountered while flushing pending bytes
 
 # 0.4.0
 * Remove Bytebuffer from public api

--- a/core/lib/output_channel0.ml
+++ b/core/lib/output_channel0.ml
@@ -34,9 +34,17 @@ module Config = struct
   ;;
 end
 
+module Flush_result = struct
+  type t =
+    | Flushed
+    | Remote_closed
+    | Error
+  [@@deriving sexp_of]
+end
+
 type flush =
   { pos : Int63.t
-  ; ivar : unit Ivar.t
+  ; ivar : Flush_result.t Ivar.t
   }
 [@@deriving sexp_of]
 
@@ -84,6 +92,17 @@ let create ?max_buffer_size ?buf_len ?write_timeout fd =
   }
 ;;
 
+let wakeup_flushes_with_error t error =
+  while not (Queue.is_empty t.flushes) do
+    Ivar.fill (Queue.dequeue_exn t.flushes).ivar error
+  done
+;;
+
+let stop_writer t reason =
+  wakeup_flushes_with_error t reason;
+  t.writer_state <- Stopped
+;;
+
 let monitor t = t.monitor
 let remote_closed t = Ivar.read t.remote_closed
 
@@ -97,11 +116,11 @@ let close_started t = Ivar.read t.close_started
 let close_finished t = Ivar.read t.close_finished
 let is_open = Fn.non is_closed
 
-let flushed t =
+let flushed_or_fail t =
   if Bytebuffer.length t.buf = 0
-  then Deferred.unit
+  then return Flush_result.Flushed
   else if is_closed t
-  then Deferred.never ()
+  then return Flush_result.Error
   else (
     let flush =
       { pos = Int63.( + ) t.bytes_written (Int63.of_int (Bytebuffer.length t.buf))
@@ -112,34 +131,44 @@ let flushed t =
     Ivar.read flush.ivar)
 ;;
 
+let flushed t =
+  match%bind flushed_or_fail t with
+  | Flush_result.Flushed -> Deferred.unit
+  | Error | Remote_closed -> Deferred.never ()
+;;
+
 let dequeue_flushes t =
   while
     (not (Queue.is_empty t.flushes))
     && Int63.( <= ) (Queue.peek_exn t.flushes).pos t.bytes_written
   do
-    Ivar.fill (Queue.dequeue_exn t.flushes).ivar ()
+    Ivar.fill (Queue.dequeue_exn t.flushes).ivar Flush_result.Flushed
   done
 ;;
 
 let write_nonblocking t =
-  Fd.syscall_exn ~nonblocking:true t.fd (fun fd ->
-    match Bytebuffer.write_assume_fd_is_nonblocking fd t.buf with
-    | n ->
-      assert (n >= 0);
-      `Ok n
-    | exception Unix.Unix_error ((EWOULDBLOCK | EAGAIN | EINTR), _, _) -> `Ok 0
-    | exception
-        Unix.Unix_error
-          ( ( EPIPE
-            | ECONNRESET
-            | EHOSTUNREACH
-            | ENETDOWN
-            | ENETRESET
-            | ENETUNREACH
-            | ETIMEDOUT )
-          , _
-          , _ ) -> `Eof
-    | exception exn -> raise exn)
+  match
+    Fd.syscall_exn ~nonblocking:true t.fd (fun fd ->
+      Bytebuffer.write_assume_fd_is_nonblocking fd t.buf)
+  with
+  | n ->
+    assert (n >= 0);
+    `Ok n
+  | exception Unix.Unix_error ((EWOULDBLOCK | EAGAIN | EINTR), _, _) -> `Ok 0
+  | exception
+      Unix.Unix_error
+        ( ( EPIPE
+          | ECONNRESET
+          | EHOSTUNREACH
+          | ENETDOWN
+          | ENETRESET
+          | ENETUNREACH
+          | ETIMEDOUT )
+        , _
+        , _ ) -> `Eof
+  | exception exn ->
+    stop_writer t Flush_result.Error;
+    raise exn
 ;;
 
 let close t =
@@ -148,14 +177,13 @@ let close t =
    | Open ->
      t.close_state <- Start_close;
      Ivar.fill t.close_started ();
-     Deferred.any_unit [ after (Time.Span.of_sec 5.); flushed t ]
+     Deferred.any_unit
+       [ after (Time.Span.of_sec 5.); Deferred.ignore_m (flushed_or_fail t) ]
      >>> fun () ->
      t.close_state <- Closed;
      Fd.close t.fd >>> fun () -> Ivar.fill t.close_finished ());
   close_finished t
 ;;
-
-let stop_writer t = t.writer_state <- Stopped
 
 module Single_write_result = struct
   type t =
@@ -166,28 +194,25 @@ end
 let rec process_write_result t = function
   | `Eof ->
     Ivar.fill t.remote_closed ();
-    stop_writer t
+    stop_writer t Flush_result.Remote_closed
   | `Ok n ->
     Bytebuffer.compact t.buf;
     t.bytes_written <- Int63.( + ) t.bytes_written (Int63.of_int n);
     dequeue_flushes t;
-    if not (Bytebuffer.length t.buf > 0)
-    then (
-      t.writer_state <- Inactive;
-      if is_closed t then stop_writer t)
+    if Bytebuffer.length t.buf <= 0
+    then t.writer_state <- Inactive
     else wait_and_write_everything t
 
 and write_everything t =
-  if Bytebuffer.length t.buf < 0
-  then (
-    t.writer_state <- Inactive;
-    if is_closed t then stop_writer t);
+  if Bytebuffer.length t.buf <= 0 then t.writer_state <- Inactive;
   if Fd.supports_nonblock t.fd
   then process_write_result t (write_nonblocking t)
   else
     Fd.syscall_in_thread t.fd ~name:"write" (fun fd -> Bytebuffer.write fd t.buf)
     >>> function
-    | `Error exn -> Exn.reraise exn "Error while writing"
+    | `Error exn ->
+      stop_writer t Flush_result.Error;
+      Exn.reraise exn "Error while writing"
     | `Ok _ as res -> process_write_result t res
     | `Already_closed -> process_write_result t `Eof
 
@@ -204,8 +229,9 @@ and wait_and_write_everything t =
          the writer."
           ~timeout:(t.config.write_timeout : Time_ns.Span.t)
           (t : t)];
-    stop_writer t
+    stop_writer t Flush_result.Error
   | `Result ((`Bad_fd | `Closed) as result) ->
+    stop_writer t Flush_result.Error;
     raise_s
       [%sexp
         "Shuttle.Output_channel: fd changed"
@@ -227,8 +253,15 @@ let schedule_flush t =
 ;;
 
 let flush t =
+  let flush_result = flushed t in
   schedule_flush t;
-  flushed t
+  flush_result
+;;
+
+let flush_or_fail t =
+  let flush_result = flushed_or_fail t in
+  schedule_flush t;
+  flush_result
 ;;
 
 let ensure_can_write t =


### PR DESCRIPTION
Wakeup pending flushes on errors and unhandled exceptions. Flush
response should also track errors.