### PR TITLE
Support timeouts for request header parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # 0.8.1
 
+* Http codec supports a timeout for reading Request headers
+
 **Bugfixes**
 
 * Fix a bug in the http request parser that could cause unhandled exception when attempting to parse certain malformed payloads.

--- a/http/src/server.ml
+++ b/http/src/server.ml
@@ -21,6 +21,7 @@ type t =
   ; reader : Input_channel.t
   ; writer : Output_channel.t
   ; error_handler : error_handler
+  ; read_header_timeout : Time_ns.Span.t
   }
 [@@deriving sexp_of]
 
@@ -112,13 +113,19 @@ let write_response t res =
           `Repeat ()))
 ;;
 
-let create ?(error_handler = default_error_handler) reader writer =
+let create
+  ?(error_handler = default_error_handler)
+  ?(read_header_timeout = Time_ns.Span.minute)
+  reader
+  writer
+  =
   let t =
     { closed = Ivar.create ()
     ; monitor = Monitor.create ()
     ; reader
     ; writer
     ; error_handler
+    ; read_header_timeout
     }
   in
   upon (Output_channel.remote_closed writer) (fun () -> Ivar.fill_if_empty t.closed ());
@@ -128,7 +135,9 @@ let create ?(error_handler = default_error_handler) reader writer =
 let handle_error t =
   Monitor.detach_and_get_next_error t.monitor
   >>> fun exn ->
-  t.error_handler ~exn `Internal_server_error
+  (match Monitor.extract_exn exn with
+   | Input_channel.Timeout -> t.error_handler `Request_timeout
+   | exn -> t.error_handler ~exn `Internal_server_error)
   >>> fun response ->
   if Ivar.is_empty t.closed
   then write_response t response >>> fun () -> Ivar.fill t.closed ()
@@ -216,29 +225,53 @@ let parse_request_body t request =
 ;;
 
 let run t handler =
-  let rec loop t =
+  let rec parse_request t =
     let view = Input_channel.view t.reader in
     match Parser.parse_request view.buf ~pos:view.pos ~len:view.len with
     | Error Partial ->
       Input_channel.refill t.reader
       >>> (function
       | `Eof -> Ivar.fill t.closed ()
-      | `Ok -> loop t)
+      | `Ok -> parse_request t)
     | Error (Fail error) ->
       t.error_handler ~exn:(Error.to_exn error) `Bad_request
       >>> fun response -> write_response t response >>> fun () -> Ivar.fill t.closed ()
     | Ok (req, consumed) ->
       Input_channel.consume t.reader consumed;
-      (match parse_request_body t req with
-       | Error e ->
-         t.error_handler ~exn:(Error.to_exn e) ~request:req `Bad_request
-         >>> fun response -> write_response t response >>> fun () -> Ivar.fill t.closed ()
-       | Ok req_body ->
-         let req = Request.with_body req req_body in
-         let promise = handler req in
-         if Deferred.is_determined promise
-         then write_response_and_continue t req (Deferred.value_exn promise)
-         else promise >>> fun response -> write_response_and_continue t req response)
+      create_request_body_reader t req
+  and parse_request_with_timeout t =
+    let rec loop span =
+      let view = Input_channel.view t.reader in
+      match Parser.parse_request view.buf ~pos:view.pos ~len:view.len with
+      | Error Partial ->
+        let now = Time_ns.now () in
+        Input_channel.refill_with_timeout t.reader span
+        >>> fun v ->
+        (match v with
+         | `Eof -> Ivar.fill t.closed ()
+         | `Ok ->
+           let now' = Time_ns.now () in
+           let diff = Time_ns.abs_diff now now' in
+           loop Time_ns.Span.(span - diff))
+      | Error (Fail error) ->
+        t.error_handler ~exn:(Error.to_exn error) `Bad_request
+        >>> fun response -> write_response t response >>> fun () -> Ivar.fill t.closed ()
+      | Ok (req, consumed) ->
+        Input_channel.consume t.reader consumed;
+        create_request_body_reader t req
+    in
+    loop t.read_header_timeout
+  and create_request_body_reader t req =
+    match parse_request_body t req with
+    | Error e ->
+      t.error_handler ~exn:(Error.to_exn e) ~request:req `Bad_request
+      >>> fun response -> write_response t response >>> fun () -> Ivar.fill t.closed ()
+    | Ok req_body ->
+      let req = Request.with_body req req_body in
+      let promise = handler req in
+      if Deferred.is_determined promise
+      then write_response_and_continue t req (Deferred.value_exn promise)
+      else promise >>> fun response -> write_response_and_continue t req response
   and write_response_and_continue t req response =
     let is_keep_alive =
       keep_alive (Request.headers req) && keep_alive (Response.headers response)
@@ -248,12 +281,22 @@ let run t handler =
     if is_keep_alive
     then (
       match Request.body req with
-      | Body.Empty | Body.Fixed _ -> loop t
+      | Body.Empty | Body.Fixed _ ->
+        if Time_ns.Span.is_positive t.read_header_timeout
+        then parse_request_with_timeout t
+        else parse_request t
       | Body.Stream (module M : Stream_intf.S) ->
-        (if M.read_started () then M.closed () else M.drain ()) >>> fun () -> loop t)
+        (if M.read_started () then M.closed () else M.drain ())
+        >>> fun () ->
+        if Time_ns.Span.is_positive t.read_header_timeout
+        then parse_request_with_timeout t
+        else parse_request t)
     else Ivar.fill t.closed ()
   in
-  Scheduler.within ~priority:Priority.normal ~monitor:t.monitor (fun () -> loop t);
+  Scheduler.within ~priority:Priority.normal ~monitor:t.monitor (fun () ->
+    if Time_ns.Span.is_positive t.read_header_timeout
+    then parse_request_with_timeout t
+    else parse_request t);
   handle_error t;
   Ivar.read t.closed
 ;;

--- a/http/src/server.mli
+++ b/http/src/server.mli
@@ -2,6 +2,10 @@ open! Core
 open! Async
 open! Shuttle
 
+(** [t] represents a server connection handle. The lifecycle for the handle is the same as
+    the underlying TCP connection. *)
+type t [@@deriving sexp_of]
+
 (** [error_handler] can be used to customize how the server deals with any unhandled
     exceptions. A default implementation is provided that will respond with a status code
     and an empty response body. *)
@@ -11,9 +15,24 @@ type error_handler = ?exn:exn -> ?request:Request.t -> Status.t -> Response.t De
     connection. *)
 type service = Request.t -> Response.t Deferred.t
 
-(** [t] represents a server connection handle. The lifecycle for the handle is the same as
-    the underlying TCP connection. *)
-type t [@@deriving sexp_of]
+(** [create ?error_handler ?read_header_timeout reader writer] creates a new server handle
+    that can be used to drive the HTTP request/response server loop.
+
+    - [error_handler] is an optional input that allows customizing how unhandled
+      exceptions, and any potential parsing or i/o errors get rendered. The default
+      implementation will attempt to send an HTTP response with a status code and an empty
+      body.
+
+    - [read_header_timeout] is the maximum time span that the server loop is allowed to
+      read a request's headers. The default value is 60 seconds. If read_header_timeout is
+      zero then no timeout is used, and the server could potentially wait forever
+      attempting to read enough data to parse request headers. *)
+val create
+  :  ?error_handler:error_handler
+  -> ?read_header_timeout:Time_ns.Span.t
+  -> Input_channel.t
+  -> Output_channel.t
+  -> t
 
 (** [closed t] returns a deferred that is resolved when the server connection handle is
     closed. *)
@@ -21,15 +40,6 @@ val closed : t -> unit Deferred.t
 
 (** [close] shuts down the http connection. *)
 val close : t -> unit
-
-(** [create ?error_handler reader writer] creates a new server handle that can be used to
-    drive the HTTP request/response server loop. *)
-val create
-  :  ?error_handler:error_handler
-  -> ?read_header_timeout:Time_ns.Span.t
-  -> Input_channel.t
-  -> Output_channel.t
-  -> t
 
 (** [run t service] accepts a server handle and a user provided service that will be
     invoked for each run of the request/response loop. *)

--- a/http/src/server.mli
+++ b/http/src/server.mli
@@ -24,7 +24,12 @@ val close : t -> unit
 
 (** [create ?error_handler reader writer] creates a new server handle that can be used to
     drive the HTTP request/response server loop. *)
-val create : ?error_handler:error_handler -> Input_channel.t -> Output_channel.t -> t
+val create
+  :  ?error_handler:error_handler
+  -> ?read_header_timeout:Time_ns.Span.t
+  -> Input_channel.t
+  -> Output_channel.t
+  -> t
 
 (** [run t service] accepts a server handle and a user provided service that will be
     invoked for each run of the request/response loop. *)

--- a/http/test/bin/dune
+++ b/http/test/bin/dune
@@ -1,5 +1,5 @@
 (executables
- (names http_server http_server_custom_error_handler)
+ (names http_server http_server_custom_error_handler http_server_timeout)
  (preprocess
   (pps ppx_jane))
  (libraries shuttle_http core_unix.command_unix))

--- a/http/test/bin/http_server_timeout.ml
+++ b/http/test/bin/http_server_timeout.ml
@@ -1,0 +1,36 @@
+open! Core
+open! Async
+open Shuttle_http
+
+let unlink f = Deferred.ignore_m (Monitor.try_with (fun () -> Unix.unlink f))
+let handler ctx _request = return (Server.respond_string ctx "Hello World")
+
+let run path =
+  let%bind () = unlink path in
+  let%bind server =
+    Shuttle.Connection.listen
+      ~input_buffer_size:0x4000
+      ~output_buffer_size:0x4000
+      ~max_accepts_per_batch:64
+      ~on_handler_error:`Raise
+      (Tcp.Where_to_listen.of_file path)
+      ~f:(fun _addr reader writer ->
+      let server =
+        Shuttle_http.Server.create
+          ~read_header_timeout:(Time_ns.Span.of_ms 100.)
+          reader
+          writer
+      in
+      Server.run server (handler server))
+  in
+  Tcp.Server.close_finished_and_handlers_determined server
+;;
+
+let () =
+  Command.async
+    ~summary:"Start an http server for use within integration tests"
+    Command.Let_syntax.(
+      let%map_open sock = anon ("socket" %: string) in
+      fun () -> run sock)
+  |> Command_unix.run
+;;

--- a/http/test/dune
+++ b/http/test/dune
@@ -7,6 +7,7 @@
   (deps
    ./bin/http_server.exe
    ./bin/http_server_custom_error_handler.exe
+   ./bin/http_server_timeout.exe
    ./id_000000,sig_06,src_000000,time_3062,execs_583,op_havoc,rep_2
    ./id_000001,sig_06,src_000000,time_4184,execs_831,op_havoc,rep_8
    ./id_000002,sig_06,src_000000,time_5043,execs_1025,op_havoc,rep_2

--- a/shuttle/lib/input_channel.mli
+++ b/shuttle/lib/input_channel.mli
@@ -20,11 +20,11 @@ val create
 val is_closed : t -> bool
 val closed : t -> unit Deferred.t
 val close : t -> unit Deferred.t
-val refill : t -> [ `Ok | `Eof ] Deferred.t
+val refill : t -> [> `Ok | `Eof ] Deferred.t
 
 exception Timeout
 
-val refill_with_timeout : t -> Time_ns.Span.t -> [ `Ok | `Eof ] Deferred.t
+val refill_with_timeout : t -> Time_ns.Span.t -> [> `Ok | `Eof ] Deferred.t
 val view : t -> slice
 val consume : t -> int -> unit
 


### PR DESCRIPTION
Real world http servers should most likely have some form of timeouts. The user provided handler does not come into play till after the runtime has had a chance to parse the request headers, so the runtime library should implement a form of timeout that ensures that the runtime only piece runs within an upper bound and the user's error handler is informed if a request header wasn't parsed within this time limit. There is no special support for timeouts for parsing request bodies and/or time duration that a handler needs to run within since those can be managed within the handler because the server context is available to the user, and can be closed at any point to shut down the connection and close the socket.

We should also most likely have a default value for this timeout that is not "infinite". I'm picking 60 seconds for now and this is documented in the mli so should be easy to discover for users creating servers.