### PR TITLE
Move `call` inside a `Oneshot` module

### DIFF
--- a/example/http_client.ml
+++ b/example/http_client.ml
@@ -3,7 +3,7 @@ open! Async
 open Shuttle_http
 
 let httpbin : Request.t -> Response.t Deferred.Or_error.t =
-  Client.call
+  Client.Oneshot.call
     ~ssl:(Client.Ssl.create ~hostname:"httpbin.org" ())
     (Tcp.Where_to_connect.of_host_and_port
        (Host_and_port.create ~host:"httpbin.org" ~port:443))

--- a/http/src/client.mli
+++ b/http/src/client.mli
@@ -22,17 +22,19 @@ module Ssl : sig
     -> t
 end
 
-(** [call] Performs a one-shot http client call to the user provided connection target. If
-    ssl options are provided the client will attempt to setup a SSL connection. If ssl
-    options contain a hostname then the client will perform hostname verification to
-    ensure the hostnames on the peer's ssl certificate matches the hostname provided by
-    the caller. To disable this check or to customize how the ssl certificate is validated
-    users can provide their own implementation of [verify_certificate] when creating the
-    {{!Shuttle_http.Client.Ssl.t} ssl} options. *)
-val call
-  :  ?interrupt:unit Deferred.t
-  -> ?connect_timeout:Time.Span.t
-  -> ?ssl:Ssl.t
-  -> 'address Tcp.Where_to_connect.t
-  -> Request.t
-  -> Response.t Deferred.Or_error.t
+module Oneshot : sig
+  (** [call] Performs a one-shot http client call to the user provided connection target.
+      If ssl options are provided the client will attempt to setup a SSL connection. If
+      ssl options contain a hostname then the client will perform hostname verification to
+      ensure the hostnames on the peer's ssl certificate matches the hostname provided by
+      the caller. To disable this check or to customize how the ssl certificate is
+      validated users can provide their own implementation of [verify_certificate] when
+      creating the {{!Shuttle_http.Client.Ssl.t} ssl} options. *)
+  val call
+    :  ?interrupt:unit Deferred.t
+    -> ?connect_timeout:Time.Span.t
+    -> ?ssl:Ssl.t
+    -> 'address Tcp.Where_to_connect.t
+    -> Request.t
+    -> Response.t Deferred.Or_error.t
+end

--- a/http/test/test_http.ml
+++ b/http/test/test_http.ml
@@ -30,7 +30,7 @@ let%expect_test "Simple http endpoint" =
 let%expect_test "Simple http endpoint with http client" =
   Helper.with_server handler ~f:(fun port ->
     let%map response =
-      Client.call
+      Client.Oneshot.call
         (Tcp.Where_to_connect.of_host_and_port
            (Host_and_port.create ~host:"localhost" ~port))
         (Request.create
@@ -171,7 +171,7 @@ let%expect_test "Client can send streaming bodies" =
     in
     let%bind response =
       Deferred.Or_error.ok_exn
-        (Client.call
+        (Client.Oneshot.call
            (Tcp.Where_to_connect.of_host_and_port
               (Host_and_port.create ~host:"localhost" ~port))
            (Request.create ~body `POST "/echo"))


### PR DESCRIPTION
The existing client call can only be used once since it closes the tcp connection after a req -> response cycle.