### PR TITLE
http_client: Add persistent http clients

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # next
 
 * Add client that supports keep-alive.
+* Add http clients that leverage Async_kernel's persistent connections.
 
 # 0.9.0
 

--- a/http/test/test_http.ml
+++ b/http/test/test_http.ml
@@ -465,6 +465,8 @@ let%expect_test "Persistent clients will re-connect if connection is closed" =
      (reason_phrase ""))
 
     Body: "This connection will be closed" |}];
+        (* Since we use persistent it will re-connent and use a fresh connection the next
+           time we use `call` *)
         let%bind response =
           Client.Persistent.call
             client


### PR DESCRIPTION
Not to be confused with HTTP/1.1 persistent connections. These are durable clients that maintain a connection to a service and eagerly and repeatedly reconnect if the underlying socket connection is lost.